### PR TITLE
Specs compliant timers + clean export

### DIFF
--- a/assets/timers.js
+++ b/assets/timers.js
@@ -1,30 +1,30 @@
-const Mainloop = imports.mainloop;
-
-const setTimeout = function(func, millis) {
-
-    let id = Mainloop.timeout_add(millis, function () {
-        func();
-        return false; // Stop repeating
-    }, null);
-
-    return id;
-};
-
-const clearTimeout = function(id) {
-
-    Mainloop.source_remove(id);
-};
-const setInterval = function(func, millis) {
-
-    let id = Mainloop.timeout_add(millis, function () {
-        func();
-        return true; // Repeat
-    }, null);
-    return id;
-};
-
-const clearInterval = function(id) {
-
-    Mainloop.source_remove(id);
-};
-
+// export only what should be exported
+const {
+  clearInterval,
+  clearTimeout,
+  setInterval,
+  setTimeout
+} = (function (Mainloop) {
+  function clear() {
+    return (id) => Mainloop.source_remove(id);
+  }
+  function set(repeat) {    // spec compliant
+    return function (fn, ms /*, ...args*/) {
+      const args = [];
+      for (let i = 2; i < arguments.length; i++) {
+        args[i - 2] = arguments[i];
+      }
+      return Mainloop.timeout_add((ms * 1) || 0, () => {
+        fn.apply(null, args);
+        return repeat; // repeat or not the interval
+      });
+    };
+  }
+  // the destructured exported object
+  return {
+    clearInterval: clear(),
+    clearTimeout: clear(),
+    setInterval: set(true),
+    setTimeout: set(false)
+  };
+}(imports.mainloop));


### PR DESCRIPTION
What do you think? I'm new to GJS (not to JS though) and I feel like the export pattern I see everywhere is very dirty.

In this change you have a clean export, only what is really needed goes out, and on top of that, the behavior of `setInterval` and `clearInterval` is standard as defined [in here](http://www.w3.org/TR/2011/WD-html5-20110525/timers.html#timers)
